### PR TITLE
Update api call timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "workflowai"
-version = "0.6.0.dev16"
+version = "0.6.0.dev17"
 description = ""
 authors = ["Guillaume Aquilina <guillaume@workflowai.com>"]
 readme = "README.md"

--- a/workflowai/core/client/_api.py
+++ b/workflowai/core/client/_api.py
@@ -35,7 +35,7 @@ class APIClient:
                 "Authorization": f"Bearer {self.api_key}",
                 **source_headers,
             },
-            timeout=120.0,
+            timeout=180.0,
         ) as client:
             try:
                 yield client


### PR DESCRIPTION
Closes https://linear.app/workflowai/issue/WOR-3795/set-sdk-timeout-to-3-minutes