### PR TITLE
test: enhance TestRunURL with additional test cases for URL generation

### DIFF
--- a/workflowai/core/domain/run_test.py
+++ b/workflowai/core/domain/run_test.py
@@ -141,26 +141,13 @@ class TestRunURL:
     # during the execution of the decorated test function. The original value is restored
     # after the test completes.
 
+    # To check what happens in different environemnt configurations, see env_test.py
+
     # Here we patch WORKFLOWAI_APP_URL to test the direct app URL case
     @patch("workflowai.env.WORKFLOWAI_APP_URL", "https://workflowai.hello")
     def test_run_url(self, run1: Run[_TestOutput]):
         # The patched value is only active during this test method
         assert run1.run_url == "https://workflowai.hello/_/agents/agent-id/runs/run-id"
-
-    # Here we patch WORKFLOWAI_API_URL to test URL derivation from API URL
-    @patch("workflowai.env.WORKFLOWAI_API_URL", "https://api.workflowai.dev")
-    def test_run_url_empty_env(self, run1: Run[_TestOutput]):
-        # When WORKFLOWAI_API_URL is set to api.workflowai.dev, the app URL should be workflowai.dev
-        # The patch is scoped only to this test method
-        assert run1.run_url == "https://workflowai.dev/_/agents/agent-id/runs/run-id"
-
-    # Multiple patches can be stacked - they are applied from bottom to top
-    # Both patches are only active for the duration of this test method
-    @patch("workflowai.env.WORKFLOWAI_API_URL", None)
-    @patch("workflowai.env.WORKFLOWAI_APP_URL", None)
-    def test_run_url_no_api_url(self, run1: Run[_TestOutput]):
-        # When WORKFLOWAI_API_URL is not set, the app URL should default to workflowai.com
-        assert run1.run_url == "https://workflowai.com/_/agents/agent-id/runs/run-id"
 
 
 class TestFetchCompletions:

--- a/workflowai/core/domain/run_test.py
+++ b/workflowai/core/domain/run_test.py
@@ -137,9 +137,30 @@ URL: https://workflowai.hello/_/agents/agent-id/runs/run-id"""
 
 
 class TestRunURL:
+    # The @patch decorator from unittest.mock temporarily replaces the value of an attribute
+    # during the execution of the decorated test function. The original value is restored
+    # after the test completes.
+
+    # Here we patch WORKFLOWAI_APP_URL to test the direct app URL case
     @patch("workflowai.env.WORKFLOWAI_APP_URL", "https://workflowai.hello")
     def test_run_url(self, run1: Run[_TestOutput]):
+        # The patched value is only active during this test method
         assert run1.run_url == "https://workflowai.hello/_/agents/agent-id/runs/run-id"
+
+    # Here we patch WORKFLOWAI_API_URL to test URL derivation from API URL
+    @patch("workflowai.env.WORKFLOWAI_API_URL", "https://api.workflowai.dev")
+    def test_run_url_empty_env(self, run1: Run[_TestOutput]):
+        # When WORKFLOWAI_API_URL is set to api.workflowai.dev, the app URL should be workflowai.dev
+        # The patch is scoped only to this test method
+        assert run1.run_url == "https://workflowai.dev/_/agents/agent-id/runs/run-id"
+
+    # Multiple patches can be stacked - they are applied from bottom to top
+    # Both patches are only active for the duration of this test method
+    @patch("workflowai.env.WORKFLOWAI_API_URL", None)
+    @patch("workflowai.env.WORKFLOWAI_APP_URL", None)
+    def test_run_url_no_api_url(self, run1: Run[_TestOutput]):
+        # When WORKFLOWAI_API_URL is not set, the app URL should default to workflowai.com
+        assert run1.run_url == "https://workflowai.com/_/agents/agent-id/runs/run-id"
 
 
 class TestFetchCompletions:

--- a/workflowai/env.py
+++ b/workflowai/env.py
@@ -4,7 +4,7 @@ import os
 
 WORKFLOWAI_DEFAULT_MODEL = os.getenv("WORKFLOWAI_DEFAULT_MODEL", "gemini-1.5-pro-latest")
 
-WORKFLOWAI_API_URL = os.getenv("WORKFLOWAI_API_URL")
+WORKFLOWAI_API_URL = os.getenv("WORKFLOWAI_API_URL", "https://run.workflowai.com")
 
 
 def _default_app_url():

--- a/workflowai/env_test.py
+++ b/workflowai/env_test.py
@@ -1,9 +1,40 @@
+import importlib
+import os
 from typing import Optional
 from unittest.mock import patch
 
 import pytest
 
-from .env import _default_app_url  # pyright: ignore[reportPrivateUsage]
+from workflowai import env
+
+
+# Check what happens when the environment is fully empty
+@patch.dict(os.environ, clear=True)
+def test_default_app_url_clear_env():
+    # We need to reload the env module so that the environment variables are read again
+    importlib.reload(env)
+    assert env.WORKFLOWAI_API_URL == "https://run.workflowai.com"
+    assert env.WORKFLOWAI_APP_URL == "https://workflowai.com"
+
+
+# Check with the default app url when an api url is provided
+@patch.dict(os.environ, {"WORKFLOWAI_API_URL": "https://run.workflowai.dev"}, clear=True)
+def test_default_app_url_dev_url():
+    importlib.reload(env)
+    assert env.WORKFLOWAI_API_URL == "https://run.workflowai.dev"
+    assert env.WORKFLOWAI_APP_URL == "https://workflowai.dev"
+
+
+# Check the app url when both api url and app url are provided
+@patch.dict(
+    os.environ,
+    {"WORKFLOWAI_API_URL": "https://run.workflowai.dev", "WORKFLOWAI_APP_URL": "https://workflowai.app"},
+    clear=True,
+)
+def test_with_app_url():
+    importlib.reload(env)
+    assert env.WORKFLOWAI_API_URL == "https://run.workflowai.dev"
+    assert env.WORKFLOWAI_APP_URL == "https://workflowai.app"
 
 
 @pytest.mark.parametrize(
@@ -16,5 +47,6 @@ from .env import _default_app_url  # pyright: ignore[reportPrivateUsage]
     ],
 )
 def test_default_app_url(api_url: Optional[str], expected: str):
+    # Importing here to avoid setting the environment variables before the test
     with patch("workflowai.env.WORKFLOWAI_API_URL", api_url):
-        assert _default_app_url() == expected
+        assert env._default_app_url() == expected  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
@guillaq I think something's off is going on with the `run_url` method. I spent some time trying to fix the issue, but wasn't successful. 

But I think I've added the tests that should fail until the bug is resolved. 